### PR TITLE
Fix L2-norm with square inside the sum.

### DIFF
--- a/src/hw2d/physical_properties/numpy_properties.py
+++ b/src/hw2d/physical_properties/numpy_properties.py
@@ -105,13 +105,11 @@ def get_energy(n: np.ndarray, phi: np.ndarray, dx: float) -> np.ndarray:
     $$ E = \\frac{1}{2} \int{d^2 x \left(n^2 + | \nabla \phi|^2 \right)} $$
     """
     #Squared L2-Norm
-    grad_phi = periodic_gradient(phi, dx=dx, axis=-1)**2 + periodic_gradient(
+    squared_norm_grad_phi = periodic_gradient(phi, dx=dx, axis=-1)**2 + periodic_gradient(
         phi, dx=dx, axis=-2
     )**2
-    # Norm
-    norm_grad_phi = grad_phi  # np.abs(grad_phi)
     # Integrate, then divide by 2
-    integral = np.mean((n**2) + norm_grad_phi, axis=(-1, -2))
+    integral = np.mean((n**2) + squared_norm_grad_phi, axis=(-1, -2))
     return integral / 2
 
 
@@ -199,8 +197,8 @@ def get_energy_V_ky(p: np.ndarray, dx: float) -> np.ndarray:
         *[np.fft.fftfreq(int(i), d=dx) * 2 * np.pi for i in p.shape[-2:]]
     )  # k(ky, kx)
     p_dft = np.fft.fft2(p, norm="ortho")
-    k = k_ky**2 + k_kx**2
-    E_V_ky = np.abs(k * p_dft * np.conjugate(p_dft)) / 2
+    squared_norm_k = k_ky**2 + k_kx**2
+    E_V_ky = np.abs(squared_norm_k * p_dft * np.conjugate(p_dft)) / 2
     E_V_ky = np.mean(E_V_ky, axis=-1)
     return E_V_ky
 

--- a/src/hw2d/physical_properties/numpy_properties.py
+++ b/src/hw2d/physical_properties/numpy_properties.py
@@ -104,13 +104,14 @@ def get_energy(n: np.ndarray, phi: np.ndarray, dx: float) -> np.ndarray:
     """Energy of the HW2D system, sum of thermal and kinetic energy
     $$ E = \\frac{1}{2} \int{d^2 x \left(n^2 + | \nabla \phi|^2 \right)} $$
     """
-    grad_phi = periodic_gradient(phi, dx=dx, axis=-1) + periodic_gradient(
+    #Squared L2-Norm
+    grad_phi = periodic_gradient(phi, dx=dx, axis=-1)**2 + periodic_gradient(
         phi, dx=dx, axis=-2
-    )
+    )**2
     # Norm
     norm_grad_phi = grad_phi  # np.abs(grad_phi)
     # Integrate, then divide by 2
-    integral = np.mean((n**2) + (norm_grad_phi**2), axis=(-1, -2))
+    integral = np.mean((n**2) + norm_grad_phi, axis=(-1, -2))
     return integral / 2
 
 
@@ -198,8 +199,8 @@ def get_energy_V_ky(p: np.ndarray, dx: float) -> np.ndarray:
         *[np.fft.fftfreq(int(i), d=dx) * 2 * np.pi for i in p.shape[-2:]]
     )  # k(ky, kx)
     p_dft = np.fft.fft2(p, norm="ortho")
-    k = k_ky + k_kx
-    E_V_ky = np.abs(k * p_dft) ** 2 / 2
+    k = k_ky**2 + k_kx**2
+    E_V_ky = np.abs(k * p_dft * np.conjugate(p_dft)) / 2
     E_V_ky = np.mean(E_V_ky, axis=-1)
     return E_V_ky
 

--- a/tests/test_numpy_properties.py
+++ b/tests/test_numpy_properties.py
@@ -32,7 +32,7 @@ def test_gamma_c():
 
 def test_energy():
     energy = get_energy(n=n, phi=p, dx=dx)
-    assert np.isclose(energy, 3.749580), energy
+    assert np.isclose(energy, 3.7285664081573486), energy
 
 
 def test_energy_N():
@@ -42,7 +42,7 @@ def test_energy_N():
 
 def test_energy_V():
     energy_V = get_energy_V_spectrally(p=p, dx=dx)
-    assert np.isclose(energy_V, 1.662893), energy_V
+    assert np.isclose(energy_V, 1.6418878080857098), energy_V
 
 
 def test_enstrophy():


### PR DESCRIPTION
The norm of the gradients was previously just the sum, which was then squared. Now get_energy and get_energy_V_ky have the correct L2-Norm.